### PR TITLE
Changed: listen address for gocarbon/carbonapi

### DIFF
--- a/ansible/vars/carbonapi.yml
+++ b/ansible/vars/carbonapi.yml
@@ -1,0 +1,3 @@
+---
+carbonapi_listeners:
+  - 0.0.0.0:8888

--- a/ansible/vars/gocarbon.yml
+++ b/ansible/vars/gocarbon.yml
@@ -1,0 +1,3 @@
+---
+gocarbon_carbonserver_listen: 0.0.0.0:8080
+

--- a/ansible/vars/icingadb_redis.yml
+++ b/ansible/vars/icingadb_redis.yml
@@ -1,2 +1,3 @@
 ---
 icingadb_redis_password: redis-pass
+icingadb_redis_logfile: ""


### PR DESCRIPTION
In this PR I changed the listen address for gocarbon and carbonapi, Like this they will be reachable over all IPs if they are not running local.
Log file Variable is also defined for icingdb-redis.